### PR TITLE
change: default watchsession timeout of 1 hour 

### DIFF
--- a/pkg/subscribe/handler.go
+++ b/pkg/subscribe/handler.go
@@ -1,6 +1,7 @@
 package subscribe
 
 import (
+	"context"
 	"encoding/json"
 	"time"
 
@@ -65,6 +66,12 @@ func handler(apiOp *types.APIRequest, getter SchemasGetter, serverVersion string
 
 	for {
 		select {
+		case <-watches.ctx.Done(): // usually because of 1h timeout for watches
+			if watches.ctx.Err() == context.DeadlineExceeded {
+				logrus.Trace("WatchSession Timeout")
+				return nil
+			}
+			return watches.ctx.Err()
 		case event, ok := <-events:
 			if !ok {
 				return nil

--- a/pkg/subscribe/watcher.go
+++ b/pkg/subscribe/watcher.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/gorilla/websocket"
 	"github.com/rancher/apiserver/pkg/types"
@@ -121,7 +122,7 @@ func NewWatchSession(apiOp *types.APIRequest, getter SchemasGetter) *WatchSessio
 		watchers: map[string]func(){},
 	}
 
-	ws.ctx, ws.cancel = context.WithCancel(apiOp.Request.Context())
+	ws.ctx, ws.cancel = context.WithTimeout(apiOp.Request.Context(), 1*time.Hour)
 	return ws
 }
 


### PR DESCRIPTION
As per standup discussion, we want to drop eternal WatchSessions.
Since re-evaluation of AuthZ during the websocket loop proved to be too complex, we re-considered having a general timeout for watch sessions.
This doesn't explicitly fix the underlying issue https://github.com/acorn-io/manager/issues/857, since in the worst case one would still be able to see updates in the UI for one hour if the WatchSession was started right before the token expired / got deleted, but that's OK for now (no destructive or intrusive actions can be taken anyway).